### PR TITLE
fix: css transition not working when stopping hover

### DIFF
--- a/src/components/ui/card/card.module.css
+++ b/src/components/ui/card/card.module.css
@@ -9,11 +9,12 @@
     border-radius: var(--theme-values-border_radius-main);
 
     overflow: hidden;
+    
+    transition: all 0.3s cubic-bezier(.14,1,.94,.85);
 }
 
 .container:hover {
     transform: scale(1.03);
-    transition: all 0.3s cubic-bezier(.14,1,.94,.85);
 }
 
 #spaced {

--- a/src/components/ui/inline-grid/inline-grid.module.css
+++ b/src/components/ui/inline-grid/inline-grid.module.css
@@ -2,11 +2,11 @@
     display: grid;
     grid-template-columns: repeat(auto-fill, 24px);
     overflow: auto visible;
+    transition: transform .4s;
 }
 
 .image:hover {
     transform: scale(1.04);
-    transition: transform .4s;
 }
 
 .image {


### PR DESCRIPTION
the css transition is only seen when hovering, so when returning to the normal state, a transition back to the other state is not seen